### PR TITLE
chore: general api changes to v2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.0](https://github.com/hostnfly/pipedrive.rb/compare/v0.3.0...v0.4.0) - 2026-02-27
+
+### Added
+- Pipedrive API v2 infrastructure (`Pipedrive::V2::Base`, `V2::Utils`, `V2::Operations::*`)
+- Cursor-based pagination for v2 endpoints
+- `x-api-token` header authentication for v2
+
 ## [v0.3.0](https://github.com/amoniacou/pipedrive.rb/compare/v0.2.0...v0.3.0) - 2020-10-10
 
 ### Merged

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/array'
 require 'active_support/concern'
 require 'active_support/inflector'
 
@@ -50,6 +51,14 @@ require 'pipedrive/operations/create'
 require 'pipedrive/operations/read'
 require 'pipedrive/operations/update'
 require 'pipedrive/operations/delete'
+
+# Core V2
+require 'pipedrive/v2/utils'
+require 'pipedrive/v2/base'
+require 'pipedrive/v2/operations/create'
+require 'pipedrive/v2/operations/read'
+require 'pipedrive/v2/operations/update'
+require 'pipedrive/v2/operations/delete'
 
 # Persons
 require 'pipedrive/person_field'

--- a/lib/pipedrive/v2/base.rb
+++ b/lib/pipedrive/v2/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    class Base < ::Pipedrive::Base
+      def build_url(args, _fields_to_select = nil)
+        url = +"/api/v2/#{entity_name}"
+        url << "/#{args[1]}" if args[1]
+        url
+      end
+
+      def connection
+        conn = self.class.connection.dup
+        conn.headers['x-api-token'] = @api_token
+        conn
+      end
+    end
+  end
+end

--- a/lib/pipedrive/v2/operations/create.rb
+++ b/lib/pipedrive/v2/operations/create.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    module Operations
+      module Create
+        extend ActiveSupport::Concern
+
+        def create(params)
+          make_api_call(:post, params)
+        end
+      end
+    end
+  end
+end

--- a/lib/pipedrive/v2/operations/delete.rb
+++ b/lib/pipedrive/v2/operations/delete.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    module Operations
+      module Delete
+        extend ActiveSupport::Concern
+
+        def delete(id)
+          make_api_call(:delete, id)
+        end
+
+        def delete_all
+          make_api_call(:delete)
+        end
+      end
+    end
+  end
+end

--- a/lib/pipedrive/v2/operations/read.rb
+++ b/lib/pipedrive/v2/operations/read.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    module Operations
+      module Read
+        extend ActiveSupport::Concern
+        include ::Enumerable
+        include ::Pipedrive::V2::Utils
+
+        def each(params = {}, &block)
+          return to_enum(:each, params) unless block_given?
+
+          follow_pagination(:chunk, [], params, &block)
+        end
+
+        def all(params = {})
+          each(params).to_a
+        end
+
+        def chunk(params = {})
+          res = make_api_call(:get, params)
+          return [] unless res.success?
+
+          res
+        end
+
+        def find_by_id(id)
+          make_api_call(:get, id)
+        end
+      end
+    end
+  end
+end

--- a/lib/pipedrive/v2/operations/update.rb
+++ b/lib/pipedrive/v2/operations/update.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    module Operations
+      module Update
+        extend ActiveSupport::Concern
+
+        def update(*args)
+          params = args.extract_options!
+          params.symbolize_keys!
+          id = params.delete(:id) || args[0]
+          raise 'id must be provided' unless id
+
+          make_api_call(:patch, id, params)
+        end
+      end
+    end
+  end
+end

--- a/lib/pipedrive/v2/utils.rb
+++ b/lib/pipedrive/v2/utils.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    module Utils
+      extend ActiveSupport::Concern
+
+      def follow_pagination(method, args, params, &block)
+        cursor = nil
+        loop do
+          pagination_params = cursor ? params.merge(cursor: cursor) : params
+          res = __send__(method, *args, pagination_params)
+          break if !res.try(:data) || !res.success?
+
+          res.data.each(&block)
+          cursor = res.try(:additional_data).try(:next_cursor)
+          break if cursor.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/lib/pipedrive/v2/base_spec.rb
+++ b/spec/lib/pipedrive/v2/base_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Base do
+  subject { described_class.new('token') }
+
+  describe '#entity_name' do
+    subject { super().entity_name }
+
+    it { is_expected.to eq described_class.name.split('::')[-1].downcase.pluralize }
+  end
+
+  context '::faraday_options' do
+    subject { described_class.faraday_options }
+
+    it 'keeps the same base URL as v1' do
+      expect(subject[:url]).to eq('https://api.pipedrive.com')
+    end
+  end
+
+  context '::connection' do
+    subject { super().connection }
+
+    it { is_expected.to be_kind_of(::Faraday::Connection) }
+  end
+
+  describe '#connection' do
+    it 'sets x-api-token header from api_token' do
+      expect(subject.connection.headers['x-api-token']).to eq('token')
+    end
+
+    it 'does not pollute the class-level connection headers' do
+      described_class.new('token_a').connection
+      described_class.new('token_b').connection
+      expect(described_class.connection.headers['x-api-token']).to be_nil
+    end
+  end
+
+  describe '#build_url' do
+    it 'uses /api/v2/ prefix' do
+      expect(subject.build_url([])).to start_with('/api/v2/')
+    end
+
+    it 'does not include api_token as query param' do
+      expect(subject.build_url([])).not_to include('api_token')
+    end
+
+    it 'appends id when provided' do
+      expect(subject.build_url([nil, 42])).to end_with('/42')
+    end
+
+    it 'ignores fields_to_select' do
+      expect(subject.build_url([], %w[a b c])).not_to include(':(')
+    end
+  end
+
+  describe '#make_api_call' do
+    let(:entity) { described_class.name.split('::')[-1].downcase.pluralize }
+
+    it 'fails with no method' do
+      expect { subject.make_api_call(test: 'foo') }.to raise_error('method param missing')
+    end
+
+    context 'without id' do
+      it 'calls :get with v2 path and x-api-token header' do
+        stub_request(:get, "https://api.pipedrive.com/api/v2/#{entity}")
+          .with(headers: { 'x-api-token' => 'token' })
+          .to_return(status: 200, body: {}.to_json, headers: {})
+        expect(subject.make_api_call(:get)).to be_success
+      end
+
+      it 'calls :post with v2 path' do
+        stub_request(:post, "https://api.pipedrive.com/api/v2/#{entity}")
+          .with(headers: { 'x-api-token' => 'token' })
+          .to_return(status: 200, body: {}.to_json, headers: {})
+        expect(subject.make_api_call(:post, test: 'bar')).to be_success
+      end
+    end
+
+    context 'with id' do
+      it 'calls :get with id in path' do
+        stub_request(:get, "https://api.pipedrive.com/api/v2/#{entity}/12")
+          .with(headers: { 'x-api-token' => 'token' })
+          .to_return(status: 200, body: {}.to_json, headers: {})
+        expect(subject.make_api_call(:get, 12)).to be_success
+      end
+
+      it 'calls :patch with id in path' do
+        stub_request(:patch, "https://api.pipedrive.com/api/v2/#{entity}/14")
+          .with(headers: { 'x-api-token' => 'token' })
+          .to_return(status: 200, body: {}.to_json, headers: {})
+        expect(subject.make_api_call(:patch, 14, test: 'bar')).to be_success
+      end
+    end
+  end
+end

--- a/spec/lib/pipedrive/v2/operations/create_spec.rb
+++ b/spec/lib/pipedrive/v2/operations/create_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Operations::Create do
+  subject do
+    Class.new(::Pipedrive::V2::Base) do
+      include ::Pipedrive::V2::Operations::Create
+    end.new('token')
+  end
+
+  describe '#create' do
+    it 'calls #make_api_call with :post' do
+      expect(subject).to receive(:make_api_call).with(:post, { foo: 'bar' })
+      subject.create(foo: 'bar')
+    end
+  end
+end

--- a/spec/lib/pipedrive/v2/operations/delete_spec.rb
+++ b/spec/lib/pipedrive/v2/operations/delete_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Operations::Delete do
+  subject do
+    Class.new(::Pipedrive::V2::Base) do
+      include ::Pipedrive::V2::Operations::Delete
+    end.new('token')
+  end
+
+  describe '#delete' do
+    it 'calls #make_api_call with :delete and id' do
+      expect(subject).to receive(:make_api_call).with(:delete, 12)
+      subject.delete(12)
+    end
+  end
+
+  describe '#delete_all' do
+    it 'calls #make_api_call with :delete' do
+      expect(subject).to receive(:make_api_call).with(:delete)
+      subject.delete_all
+    end
+  end
+end

--- a/spec/lib/pipedrive/v2/operations/read_spec.rb
+++ b/spec/lib/pipedrive/v2/operations/read_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Operations::Read do
+  subject do
+    Class.new(::Pipedrive::V2::Base) do
+      include ::Pipedrive::V2::Operations::Read
+    end.new('token')
+  end
+
+  describe '#find_by_id' do
+    it 'calls #make_api_call' do
+      expect(subject).to receive(:make_api_call).with(:get, 12)
+      subject.find_by_id(12)
+    end
+  end
+
+  describe '#each' do
+    it 'returns Enumerator if no block given' do
+      expect(subject.each).to be_a(::Enumerator)
+    end
+
+    it 'calls to_enum with params' do
+      expect(subject).to receive(:to_enum).with(:each, { foo: 'bar' })
+      subject.each(foo: 'bar')
+    end
+
+    it 'yields data from a single page' do
+      expect(subject).to receive(:chunk).and_return(
+        ::Hashie::Mash.new(data: [1, 2], success: true, additional_data: { next_cursor: nil })
+      )
+      expect { |b| subject.each(&b) }.to yield_successive_args(1, 2)
+    end
+
+    it 'follows cursor-based pagination' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(data: [1, 2], success: true, additional_data: { next_cursor: 'abc' })
+      )
+      expect(subject).to receive(:chunk).with(cursor: 'abc').and_return(
+        ::Hashie::Mash.new(data: [3, 4], success: true, additional_data: { next_cursor: nil })
+      )
+      expect { |b| subject.each(&b) }.to yield_successive_args(1, 2, 3, 4)
+    end
+
+    it 'does not yield anything if result has no data' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(success: true)
+      )
+      expect { |b| subject.each(&b) }.to yield_successive_args
+    end
+
+    it 'does not yield anything if result is not success' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(success: false)
+      )
+      expect { |b| subject.each(&b) }.to yield_successive_args
+    end
+  end
+
+  describe '#all' do
+    it 'calls #each and returns array' do
+      arr = double('enumerator')
+      allow(arr).to receive(:to_a)
+      expect(subject).to receive(:each).and_return(arr)
+      subject.all
+    end
+  end
+
+  describe '#chunk' do
+    it 'returns [] on failed response' do
+      res = double('res', success?: false)
+      expect(subject).to receive(:make_api_call).with(:get, {}).and_return(res)
+      expect(subject.chunk).to eq([])
+    end
+
+    it 'returns result on success' do
+      res = double('res', success?: true)
+      expect(subject).to receive(:make_api_call).with(:get, {}).and_return(res)
+      expect(subject.chunk).to eq(res)
+    end
+  end
+end

--- a/spec/lib/pipedrive/v2/operations/update_spec.rb
+++ b/spec/lib/pipedrive/v2/operations/update_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Operations::Update do
+  subject do
+    Class.new(::Pipedrive::V2::Base) do
+      include ::Pipedrive::V2::Operations::Update
+    end.new('token')
+  end
+
+  describe '#update' do
+    it 'calls #make_api_call with :patch' do
+      expect(subject).to receive(:make_api_call).with(:patch, 12, { foo: 'bar' })
+      subject.update(12, foo: 'bar')
+    end
+
+    it 'calls #make_api_call with id in params' do
+      expect(subject).to receive(:make_api_call).with(:patch, 14, { foo: 'bar' })
+      subject.update(foo: 'bar', id: 14)
+    end
+
+    it 'raises when id is missing' do
+      expect { subject.update(foo: 'bar') }.to raise_error('id must be provided')
+    end
+  end
+end

--- a/spec/lib/pipedrive/v2/utils_spec.rb
+++ b/spec/lib/pipedrive/v2/utils_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Utils do
+  subject do
+    Class.new(::Pipedrive::V2::Base) do
+      include ::Pipedrive::V2::Utils
+    end.new('token')
+  end
+
+  describe '#follow_pagination' do
+    it 'yields all items from a single page with no next cursor' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(data: [1, 2], success: true, additional_data: { next_cursor: nil })
+      )
+      results = []
+      subject.follow_pagination(:chunk, [], {}) { |item| results << item }
+      expect(results).to eq([1, 2])
+    end
+
+    it 'follows cursor across multiple pages' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(data: [1, 2], success: true, additional_data: { next_cursor: 'abc' })
+      )
+      expect(subject).to receive(:chunk).with(cursor: 'abc').and_return(
+        ::Hashie::Mash.new(data: [3, 4], success: true, additional_data: { next_cursor: nil })
+      )
+      results = []
+      subject.follow_pagination(:chunk, [], {}) { |item| results << item }
+      expect(results).to eq([1, 2, 3, 4])
+    end
+
+    it 'stops when response has no data' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(success: true)
+      )
+      results = []
+      subject.follow_pagination(:chunk, [], {}) { |item| results << item }
+      expect(results).to be_empty
+    end
+
+    it 'stops when response is not successful' do
+      expect(subject).to receive(:chunk).with({}).and_return(
+        ::Hashie::Mash.new(success: false)
+      )
+      results = []
+      subject.follow_pagination(:chunk, [], {}) { |item| results << item }
+      expect(results).to be_empty
+    end
+
+    it 'does not send cursor param on first request' do
+      expect(subject).to receive(:chunk) do |params|
+        expect(params).not_to have_key(:cursor)
+        ::Hashie::Mash.new(data: [], success: true)
+      end
+      subject.follow_pagination(:chunk, [], {}) { }
+    end
+  end
+end


### PR DESCRIPTION
## feat: add Pipedrive API v2 infrastructure

This PR introduces the foundational layer for supporting Pipedrive API v2 endpoints
alongside the existing v1 API, without breaking any current behaviour.

## What's new

- `Pipedrive::V2::Base` — base class for all future v2 endpoints. Builds URLs under
  `/api/v2/` and authenticates via `x-api-token` header instead of a query parameter
- `Pipedrive::V2::Utils` — cursor-based pagination replacing the offset-based
  `start` / `more_items_in_collection` approach from v1
- `Pipedrive::V2::Operations::Create` — POST operations (v2 namespace)
- `Pipedrive::V2::Operations::Read` — read operations backed by cursor pagination
- `Pipedrive::V2::Operations::Update` — uses `PATCH` instead of `PUT`
- `Pipedrive::V2::Operations::Delete` — DELETE operations (v2 namespace)

## Design decisions

- V2 classes live under `lib/pipedrive/v2/` (`Pipedrive::V2::` namespace), keeping
  v1 and v2 fully isolated — no risk to existing integrations
- Adding a new v2 endpoint in a future PR is a one-liner: inherit from
  `Pipedrive::V2::Base` and include the 4 `V2::Operations::*` modules
- Sorting changes (`sort_by` / `sort_direction` instead of `sort`) are user-land —
  no gem change needed

## Out of scope

The actual migration of the `Activity` endpoint to v2 is handled in the next PR.

[Pipedrive documentation](https://pipedrive.readme.io/docs/pipedrive-api-v2-migration-guide#general-api-changes)