### PR TITLE
fix: v2 json request body

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,13 +94,19 @@ module Pipedrive
       # :nodoc
       def connection
         @connection ||= Faraday.new(faraday_options) do |conn|
-          conn.request :url_encoded
+          conn.request params_format
           conn.response :mashify
           conn.response :json, content_type: /\bjson$/
           conn.use FaradayMiddleware::ParseJson
           conn.response :logger, ::Pipedrive.logger if ::Pipedrive.debug
           conn.adapter Faraday.default_adapter
         end
+      end
+
+      private
+
+      def params_format
+        :url_encoded
       end
     end
   end

--- a/lib/pipedrive/v2/base.rb
+++ b/lib/pipedrive/v2/base.rb
@@ -3,6 +3,15 @@
 module Pipedrive
   module V2
     class Base < ::Pipedrive::Base
+      class << self
+        private
+
+        # V2 API requires JSON request bodies to preserve integer types.
+        def params_format
+          :json
+        end
+      end
+
       def build_url(args, _fields_to_select = nil)
         url = +"/api/v2/#{entity_name}"
         url << "/#{args[1]}" if args[1]

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/lib/pipedrive/v2/base_spec.rb
+++ b/spec/lib/pipedrive/v2/base_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe ::Pipedrive::V2::Base do
       end
     end
 
+    context 'request body encoding' do
+      it 'sends body as JSON with integer values preserved' do
+        stub_request(:post, "https://api.pipedrive.com/api/v2/#{entity}")
+          .with(
+            headers: { 'Content-Type' => 'application/json' },
+            body: { owner_id: 11592426 }.to_json
+          )
+          .to_return(status: 200, body: {}.to_json, headers: {})
+        expect(subject.make_api_call(:post, owner_id: 11592426)).to be_success
+      end
+    end
+
     context 'with id' do
       it 'calls :get with id in path' do
         stub_request(:get, "https://api.pipedrive.com/api/v2/#{entity}/12")


### PR DESCRIPTION
Fix: V2 API — owner_id rejected as string

The Pipedrive V2 API enforces strict JSON schema validation. Our Faraday connection was sending request bodies as URL-encoded form data (owner_id=11592426), which Pipedrive V2 receives as the string "11592426" instead of the integer 11592426 — causing the request to be rejected. (TEST on backend side)

Fix: Override the Faraday connection in Pipedrive::V2::Base to use conn.request :json instead of conn.request :url_encoded, so integer fields are correctly typed in the request body.
