### PR TITLE
feat: bump organizations api v2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.0](https://github.com/hostnfly/pipedrive.rb/compare/v0.4.3...v0.5.0) - 2026-06-24
+
+### Added
+- `Pipedrive::V2::Organization` — Organizations endpoint migrated to API v2
+
 ## [v0.4.3](https://github.com/hostnfly/pipedrive.rb/compare/v0.4.2...v0.4.3) - 2026-06-18
 
 ### Added

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -67,6 +67,7 @@ require 'pipedrive/person'
 # Organizations
 require 'pipedrive/organization_field'
 require 'pipedrive/organization'
+require 'pipedrive/v2/organization'
 
 # Filters
 require 'pipedrive/filter'

--- a/lib/pipedrive/v2/organization.rb
+++ b/lib/pipedrive/v2/organization.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  module V2
+    class Organization < ::Pipedrive::V2::Base
+      include ::Pipedrive::V2::Operations::Create
+      include ::Pipedrive::V2::Operations::Read
+      include ::Pipedrive::V2::Operations::Update
+      include ::Pipedrive::V2::Operations::Delete
+    end
+  end
+end

--- a/lib/pipedrive/version.rb
+++ b/lib/pipedrive/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pipedrive
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end

--- a/spec/lib/pipedrive/v2/organization_spec.rb
+++ b/spec/lib/pipedrive/v2/organization_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::V2::Organization do
+  subject { described_class.new('token') }
+
+  describe '#entity_name' do
+    it { expect(subject.entity_name).to eq('organizations') }
+  end
+
+  describe '#build_url' do
+    it 'uses /api/v2/organizations' do
+      expect(subject.build_url([])).to eq('/api/v2/organizations')
+    end
+
+    it 'appends id when provided' do
+      expect(subject.build_url([nil, 42])).to eq('/api/v2/organizations/42')
+    end
+
+    it 'does not include api_token as query param' do
+      expect(subject.build_url([])).not_to include('api_token')
+    end
+  end
+
+  describe '#connection' do
+    it 'authenticates via x-api-token header' do
+      expect(subject.connection.headers['x-api-token']).to eq('token')
+    end
+  end
+
+  describe '#create' do
+    it 'POSTs to /api/v2/organizations with x-api-token header' do
+      stub_request(:post, 'https://api.pipedrive.com/api/v2/organizations')
+        .with(headers: { 'x-api-token' => 'token' })
+        .to_return(status: 200, body: { success: true, data: {} }.to_json, headers: {})
+      expect(subject.create(name: 'Acme')).to be_success
+    end
+  end
+
+  describe '#find_by_id' do
+    it 'GETs /api/v2/organizations/:id with x-api-token header' do
+      stub_request(:get, 'https://api.pipedrive.com/api/v2/organizations/1')
+        .with(headers: { 'x-api-token' => 'token' })
+        .to_return(status: 200, body: { success: true, data: {} }.to_json, headers: {})
+      expect(subject.find_by_id(1)).to be_success
+    end
+  end
+
+  describe '#update' do
+    it 'PATCHes /api/v2/organizations/:id with x-api-token header' do
+      stub_request(:patch, 'https://api.pipedrive.com/api/v2/organizations/1')
+        .with(headers: { 'x-api-token' => 'token' })
+        .to_return(status: 200, body: { success: true, data: {} }.to_json, headers: {})
+      expect(subject.update(1, name: 'Acme Updated')).to be_success
+    end
+  end
+
+  describe '#delete' do
+    it 'DELETEs /api/v2/organizations/:id with x-api-token header' do
+      stub_request(:delete, 'https://api.pipedrive.com/api/v2/organizations/1')
+        .with(headers: { 'x-api-token' => 'token' })
+        .to_return(status: 200, body: { success: true }.to_json, headers: {})
+      expect(subject.delete(1)).to be_success
+    end
+  end
+
+  describe '#all' do
+    it 'uses cursor-based pagination' do
+      stub_request(:get, 'https://api.pipedrive.com/api/v2/organizations')
+        .with(headers: { 'x-api-token' => 'token' })
+        .to_return(
+          status: 200,
+          body: { success: true, data: [{ id: 1 }, { id: 2 }], additional_data: { next_cursor: 'abc' } }.to_json,
+          headers: {}
+        )
+      stub_request(:get, 'https://api.pipedrive.com/api/v2/organizations')
+        .with(headers: { 'x-api-token' => 'token' }, query: { 'cursor' => 'abc' })
+        .to_return(
+          status: 200,
+          body: { success: true, data: [{ id: 3 }], additional_data: { next_cursor: nil } }.to_json,
+          headers: {}
+        )
+      expect(subject.all.length).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
We chose to bump the minor version rather than the patch because introducing V2 classes alongside the existing V1 ones is a meaningful API expansion — consumers need to opt in explicitly by switching to Pipedrive::V2::*. This also gives us room to release fixes as 0.5.x if any issues come up during the v2 rollout in the backend, without conflating them with future unrelated patch releases on 0.4.x.

@batistadasilva a thought ?